### PR TITLE
Fix Spring bean cycle via circuit breaker disable path

### DIFF
--- a/src/main/java/net/friendly_bets/scrape/ExternalApiCircuitBreaker.java
+++ b/src/main/java/net/friendly_bets/scrape/ExternalApiCircuitBreaker.java
@@ -3,7 +3,7 @@ package net.friendly_bets.scrape;
 import lombok.RequiredArgsConstructor;
 import net.friendly_bets.providers.ExternalDataLayer;
 import net.friendly_bets.services.ErrorLogService;
-import net.friendly_bets.services.ExternalDataLayerConfigService;
+import net.friendly_bets.services.ExternalDataLayerAutoDisableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +15,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * After consecutive trip-worthy failures, disables the layer in MongoDB until an admin re-enables it.
+ * Depends on {@link ExternalDataLayerAutoDisableService} (not ConfigService) to avoid a bean cycle
+ * through LayerProviderRegistry → providers → HTTP clients.
  */
 @Service
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public class ExternalApiCircuitBreaker {
 
     public static final String CODE_LAYER_CIRCUIT_OPEN = "layerCircuitOpen";
 
-    private final ExternalDataLayerConfigService layerConfigService;
+    private final ExternalDataLayerAutoDisableService layerAutoDisableService;
     private final ErrorLogService errorLogService;
 
     @Value("${external-data.circuit-breaker.failure-threshold:3}")
@@ -60,7 +62,7 @@ public class ExternalApiCircuitBreaker {
         consecutiveFailures.get(layer).set(0);
         String message = "Circuit open after " + count + " consecutive " + kind
                 + (detail != null && !detail.isBlank() ? ": " + detail : "");
-        boolean disabled = layerConfigService.disableLayer(layer, message);
+        boolean disabled = layerAutoDisableService.disableLayer(layer, message);
         errorLogService.record(ErrorLogService.Entry.builder()
                 .severity(ErrorLogService.SEVERITY_ERROR)
                 .layer(layer.name())

--- a/src/main/java/net/friendly_bets/services/ExternalDataLayerAutoDisableService.java
+++ b/src/main/java/net/friendly_bets/services/ExternalDataLayerAutoDisableService.java
@@ -1,0 +1,58 @@
+package net.friendly_bets.services;
+
+import lombok.RequiredArgsConstructor;
+import net.friendly_bets.models.AppSettings;
+import net.friendly_bets.providers.ExternalDataLayer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Persists {@code enabled=false} for a layer without depending on {@link LayerProviderRegistry}.
+ * Used by the scrape circuit breaker to avoid a Spring bean cycle:
+ * ConfigService → Registry → Providers → HttpClients → CircuitBreaker → ConfigService.
+ */
+@Service
+@RequiredArgsConstructor
+public class ExternalDataLayerAutoDisableService {
+
+    private final AppSettingsService appSettingsService;
+
+    /**
+     * Persist {@code enabled=false} for a layer (circuit breaker). Returns true when the flag changed.
+     */
+    @Transactional
+    public boolean disableLayer(ExternalDataLayer layer, String reason) {
+        if (layer == null) {
+            return false;
+        }
+        AppSettings settings = appSettingsService.getOrCreate();
+        AppSettings.ExternalDataLayersBlock block = settings.getExternalDataLayers();
+        if (block == null || block.getLayers() == null) {
+            block = appSettingsService.defaultExternalDataLayers();
+            settings.setExternalDataLayers(block);
+        }
+        Map<ExternalDataLayer, AppSettings.LayerAssignment> layers = new EnumMap<>(ExternalDataLayer.class);
+        if (block.getLayers() != null) {
+            layers.putAll(block.getLayers());
+        }
+        for (ExternalDataLayer l : ExternalDataLayer.values()) {
+            layers.putIfAbsent(l, appSettingsService.defaultLayerAssignment(l));
+        }
+        AppSettings.LayerAssignment current = layers.get(layer);
+        if (current != null && Boolean.FALSE.equals(current.getEnabled())) {
+            return false;
+        }
+        AppSettings.LayerAssignment next = AppSettings.LayerAssignment.builder()
+                .enabled(false)
+                .primaryProvider(current != null ? current.getPrimaryProvider() : null)
+                .secondaryProvider(current != null ? current.getSecondaryProvider() : null)
+                .build();
+        layers.put(layer, next);
+        settings.setExternalDataLayers(AppSettings.ExternalDataLayersBlock.builder().layers(layers).build());
+        appSettingsService.save(settings);
+        return true;
+    }
+}

--- a/src/main/java/net/friendly_bets/services/ExternalDataLayerConfigService.java
+++ b/src/main/java/net/friendly_bets/services/ExternalDataLayerConfigService.java
@@ -52,42 +52,6 @@ public class ExternalDataLayerConfigService {
         return externalDataProperties.isLayerEnabled(layer);
     }
 
-    /**
-     * Persist {@code enabled=false} for a layer (circuit breaker). Returns true when the flag changed.
-     */
-    @Transactional
-    public boolean disableLayer(ExternalDataLayer layer, String reason) {
-        if (layer == null) {
-            return false;
-        }
-        AppSettings settings = appSettingsService.getOrCreate();
-        AppSettings.ExternalDataLayersBlock block = settings.getExternalDataLayers();
-        if (block == null || block.getLayers() == null) {
-            block = appSettingsService.defaultExternalDataLayers();
-            settings.setExternalDataLayers(block);
-        }
-        Map<ExternalDataLayer, AppSettings.LayerAssignment> layers = new EnumMap<>(ExternalDataLayer.class);
-        if (block.getLayers() != null) {
-            layers.putAll(block.getLayers());
-        }
-        for (ExternalDataLayer l : ExternalDataLayer.values()) {
-            layers.putIfAbsent(l, appSettingsService.defaultLayerAssignment(l));
-        }
-        AppSettings.LayerAssignment current = layers.get(layer);
-        if (current != null && Boolean.FALSE.equals(current.getEnabled())) {
-            return false;
-        }
-        AppSettings.LayerAssignment next = AppSettings.LayerAssignment.builder()
-                .enabled(false)
-                .primaryProvider(current != null ? current.getPrimaryProvider() : null)
-                .secondaryProvider(current != null ? current.getSecondaryProvider() : null)
-                .build();
-        layers.put(layer, next);
-        settings.setExternalDataLayers(AppSettings.ExternalDataLayersBlock.builder().layers(layers).build());
-        appSettingsService.save(settings);
-        return true;
-    }
-
     @Transactional
     public AppSettings.ExternalDataLayersBlock update(Map<ExternalDataLayer, AppSettings.LayerAssignment> layers) {
         if (layers == null) {

--- a/src/test/java/net/friendly_bets/scrape/ExternalApiCircuitBreakerTest.java
+++ b/src/test/java/net/friendly_bets/scrape/ExternalApiCircuitBreakerTest.java
@@ -2,7 +2,7 @@ package net.friendly_bets.scrape;
 
 import net.friendly_bets.providers.ExternalDataLayer;
 import net.friendly_bets.services.ErrorLogService;
-import net.friendly_bets.services.ExternalDataLayerConfigService;
+import net.friendly_bets.services.ExternalDataLayerAutoDisableService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -23,7 +23,7 @@ class ExternalApiCircuitBreakerTest {
 
     @BeforeEach
     void setUp() {
-        ExternalDataLayerConfigService config = new ExternalDataLayerConfigService(null, null, null) {
+        ExternalDataLayerAutoDisableService autoDisable = new ExternalDataLayerAutoDisableService(null) {
             @Override
             public boolean disableLayer(ExternalDataLayer layer, String reason) {
                 disableCalls.incrementAndGet();
@@ -36,7 +36,7 @@ class ExternalApiCircuitBreakerTest {
                 logged.add(entry);
             }
         };
-        breaker = new ExternalApiCircuitBreaker(config, errors);
+        breaker = new ExternalApiCircuitBreaker(autoDisable, errors);
         ReflectionTestUtils.setField(breaker, "failureThreshold", 3);
         disableCalls.set(0);
         logged.clear();


### PR DESCRIPTION
ExternalApiCircuitBreaker no longer depends on ExternalDataLayerConfigService (which pulls LayerProviderRegistry → providers → HTTP clients). Disable logic moved to ExternalDataLayerAutoDisableService (AppSettings only).