### PR TITLE
Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Spring Boot 2.7 (Java 17) REST API for the "Friendly Bets" app. Frontend lives in a separate repo (`friendly-bets-frontend`).
+
+### Services / how to run
+- Build: `mvn -DskipTests clean package` (requires Java 17 — `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64`; the project targets Java 17, not the system-default JDK).
+- Run (dev): `mvn spring-boot:run -Dspring-boot.run.profiles=dev` → serves on port `8080`; root `/` redirects to `/swagger-ui.html`.
+- Test: `mvn test` (unit + integration tests; integration tests use flapdoodle embedded Mongo by default, so they do NOT need a running MongoDB).
+
+### MongoDB requirement (non-obvious)
+- The app uses MongoDB **transactions**, which require a **replica set**. A standalone `mongod` fails at startup with `Transaction numbers are only allowed on a replica set member or mongos`.
+- Run MongoDB as a single-node replica set: `mongod --dbpath /data/db --replSet rs0 --fork --logpath /var/log/mongodb/mongod.log`, then once: `mongosh --eval 'rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})'`.
+- `mongod` is started manually (no systemd in the VM). The replica-set config persists in `/data/db`, so after a restart you only need to start `mongod` again (no re-initiate).
+
+### Config (non-obvious)
+- The **dev** profile imports `./db.properties` (git-ignored). It must exist at the repo root with `mongodb.uri=mongodb://localhost:27017`. Without it, dev startup fails on placeholder `${mongodb.uri}`.
+- Mail is disabled by default (`app.mail.enabled=false`) and email confirmation is not required for login, so registration + login work fully offline. New accounts show an "email not confirmed" banner — this is expected, not a bug.
+- External data scrapers (Marathonbet/Melbet/Soccer365/etc.) hit the public internet; not needed to run/test the core app.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and documents the development environment for the Friendly Bets backend (Spring Boot 2.7 / Java 17).

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious setup/run caveats discovered while getting the app running:
- Requires Java 17 (`JAVA_HOME`), not the system-default JDK.
- MongoDB must run as a **single-node replica set** (the app uses transactions); a standalone `mongod` fails at startup.
- The `dev` profile imports a git-ignored `db.properties` (`mongodb.uri=mongodb://localhost:27017`).
- Mail/email-confirmation are off by default, so register + login work offline.

## Verification
- `mvn -DskipTests clean package` — build succeeds.
- `mvn test` — 422 tests pass (0 failures, 0 errors, 1 skipped).
- `mvn spring-boot:run -Dspring-boot.run.profiles=dev` — starts on `:8080`.
- End-to-end: `POST /api/register` → 201, `POST /api/login` → 200, `GET /api/users/my/profile` → 200 (data persisted in MongoDB).

No application code was changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a34d94e0-4a7a-4272-b106-a63d781b5c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a34d94e0-4a7a-4272-b106-a63d781b5c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

