### PR TITLE
Invert HTTP monitoring ratio and log failed HTTP to error log

### DIFF
--- a/src/main/java/net/friendly_bets/repositories/ErrorLogRepository.java
+++ b/src/main/java/net/friendly_bets/repositories/ErrorLogRepository.java
@@ -19,6 +19,14 @@ public interface ErrorLogRepository extends MongoRepository<ErrorLog, String> {
             String message
     );
 
+    Optional<ErrorLog> findFirstByProviderAndCodeAndLayerAndLeagueCodeAndMessage(
+            String provider,
+            String code,
+            String layer,
+            String leagueCode,
+            String message
+    );
+
     List<ErrorLog> findByCodeAndHomeTeam(String code, String homeTeam);
 
     List<ErrorLog> findByCodeAndAwayTeam(String code, String awayTeam);

--- a/src/main/java/net/friendly_bets/services/ErrorLogService.java
+++ b/src/main/java/net/friendly_bets/services/ErrorLogService.java
@@ -6,6 +6,7 @@ import lombok.Value;
 import net.friendly_bets.dto.ErrorLogDto;
 import net.friendly_bets.exceptions.NotFoundException;
 import net.friendly_bets.models.ErrorLog;
+import net.friendly_bets.models.monitoring.ExternalApiHttpLogEntry;
 import net.friendly_bets.models.schedule.MatchSchedule;
 import net.friendly_bets.providers.ExternalDataLayer;
 import net.friendly_bets.repositories.ErrorLogRepository;
@@ -105,6 +106,83 @@ public class ErrorLogService {
         } catch (Exception e) {
             log.warn("Failed to persist error_log: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Logs failed outbound HTTP from a monitoring run when callers did not already record
+     * {@link #CODE_PROVIDER_FETCH_FAILED} with the same provider, layer, league and message.
+     */
+    public void recordHttpRequestFailuresIfNeeded(
+            ExternalDataLayer layer,
+            String provider,
+            String leagueCode,
+            String season,
+            List<ExternalApiHttpLogEntry> httpLogs,
+            String errorSummary
+    ) {
+        int failed = countFailedHttpLogs(httpLogs);
+        if (failed <= 0) {
+            return;
+        }
+        String message = buildHttpFailureMessage(httpLogs, errorSummary);
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        String providerNorm = blankToNull(provider);
+        String layerName = layer != null ? layer.name() : null;
+        String leagueNorm = blankToNull(leagueCode);
+        if (providerNorm != null
+                && errorLogRepository.findFirstByProviderAndCodeAndLayerAndLeagueCodeAndMessage(
+                providerNorm,
+                CODE_PROVIDER_FETCH_FAILED,
+                layerName,
+                leagueNorm,
+                message.trim()).isPresent()) {
+            return;
+        }
+        record(Entry.builder()
+                .severity(SEVERITY_ERROR)
+                .layer(layerName)
+                .provider(provider)
+                .code(CODE_PROVIDER_FETCH_FAILED)
+                .message(message.trim())
+                .leagueCode(leagueCode)
+                .season(blankToNull(season))
+                .build());
+    }
+
+    private static String buildHttpFailureMessage(List<ExternalApiHttpLogEntry> httpLogs, String errorSummary) {
+        if (errorSummary != null && !errorSummary.isBlank()) {
+            return errorSummary.trim();
+        }
+        int total = httpLogs != null ? httpLogs.size() : 0;
+        int failed = countFailedHttpLogs(httpLogs);
+        int success = Math.max(0, total - failed);
+        StringBuilder sb = new StringBuilder();
+        sb.append("httpSuccess=").append(success).append("/").append(total);
+        if (httpLogs != null) {
+            for (ExternalApiHttpLogEntry entry : httpLogs) {
+                if (entry.getOutcome() == null || "SUCCESS".equals(entry.getOutcome())) {
+                    continue;
+                }
+                sb.append("; ");
+                sb.append(entry.getRequestType() != null ? entry.getRequestType() : "?");
+                sb.append(":").append(entry.getOutcome());
+                if (entry.getDetail() != null && !entry.getDetail().isBlank()) {
+                    sb.append(" — ").append(entry.getDetail().trim());
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static int countFailedHttpLogs(List<ExternalApiHttpLogEntry> logs) {
+        if (logs == null || logs.isEmpty()) {
+            return 0;
+        }
+        return (int) logs.stream()
+                .filter(e -> e.getOutcome() != null && !"SUCCESS".equals(e.getOutcome()))
+                .count();
     }
 
     public void recordLayerFailure(

--- a/src/main/java/net/friendly_bets/services/ExternalApiMonitoringService.java
+++ b/src/main/java/net/friendly_bets/services/ExternalApiMonitoringService.java
@@ -60,6 +60,7 @@ public class ExternalApiMonitoringService {
     }
 
     private final ExternalApiMonitoringRepository repository;
+    private final ErrorLogService errorLogService;
 
     public static void setTriggerOverride(ExternalApiMonitoringTrigger trigger) {
         TRIGGER_OVERRIDE.set(trigger);
@@ -114,6 +115,16 @@ public class ExternalApiMonitoringService {
         run.setHttpLogs(new ArrayList<>(logs));
         run.setHttpRequestsTotal(logs.size());
         run.setHttpRequestsFailed(countFailed(logs));
+        if (run.getHttpRequestsFailed() > 0) {
+            errorLogService.recordHttpRequestFailuresIfNeeded(
+                    run.getLayer(),
+                    run.getProvider(),
+                    run.getLeagueCode(),
+                    run.getSeason(),
+                    logs,
+                    errorSummary
+            );
+        }
         if (failedMatchScheduleIds != null && !failedMatchScheduleIds.isEmpty()) {
             run.setFailedMatchScheduleIds(new ArrayList<>(new LinkedHashSet<>(failedMatchScheduleIds)));
         }

--- a/src/test/java/net/friendly_bets/services/ErrorLogServiceHttpFailuresTest.java
+++ b/src/test/java/net/friendly_bets/services/ErrorLogServiceHttpFailuresTest.java
@@ -1,0 +1,107 @@
+package net.friendly_bets.services;
+
+import net.friendly_bets.models.ErrorLog;
+import net.friendly_bets.models.monitoring.ExternalApiHttpLogEntry;
+import net.friendly_bets.providers.ExternalDataLayer;
+import net.friendly_bets.repositories.ErrorLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ErrorLogServiceHttpFailuresTest {
+
+    private ErrorLogRepository repository;
+    private ErrorLogService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ErrorLogRepository.class);
+        service = new ErrorLogService(repository);
+    }
+
+    @Test
+    void recordHttpRequestFailuresIfNeeded_skipsWhenAllSucceeded() {
+        List<ExternalApiHttpLogEntry> logs = List.of(
+                ExternalApiHttpLogEntry.builder().outcome("SUCCESS").build()
+        );
+        service.recordHttpRequestFailuresIfNeeded(
+                ExternalDataLayer.SCHEDULE,
+                "sports.ru",
+                "EPL",
+                "2025",
+                logs,
+                null
+        );
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void recordHttpRequestFailuresIfNeeded_logsBuiltMessageWhenNoSummary() {
+        List<ExternalApiHttpLogEntry> logs = List.of(
+                ExternalApiHttpLogEntry.builder().outcome("SUCCESS").requestType("SCHEDULE_PAGE").build(),
+                ExternalApiHttpLogEntry.builder()
+                        .outcome("HTTP_ERROR")
+                        .requestType("MATCH_PAGE")
+                        .detail("timeout")
+                        .build()
+        );
+        when(repository.findFirstByProviderAndCodeAndLayerAndLeagueCodeAndMessage(
+                eq("sports.ru"),
+                eq(ErrorLogService.CODE_PROVIDER_FETCH_FAILED),
+                eq("SCHEDULE"),
+                eq("EPL"),
+                any())).thenReturn(Optional.empty());
+
+        service.recordHttpRequestFailuresIfNeeded(
+                ExternalDataLayer.SCHEDULE,
+                "sports.ru",
+                "EPL",
+                "2025",
+                logs,
+                null
+        );
+
+        ArgumentCaptor<ErrorLog> captor = ArgumentCaptor.forClass(ErrorLog.class);
+        verify(repository).save(captor.capture());
+        assertEquals(ErrorLogService.CODE_PROVIDER_FETCH_FAILED, captor.getValue().getCode());
+        assertTrue(captor.getValue().getMessage().startsWith("httpSuccess=1/2"));
+        assertTrue(captor.getValue().getMessage().contains("MATCH_PAGE:HTTP_ERROR"));
+    }
+
+    @Test
+    void recordHttpRequestFailuresIfNeeded_skipsDuplicateProviderFetchFailed() {
+        List<ExternalApiHttpLogEntry> logs = new ArrayList<>();
+        logs.add(ExternalApiHttpLogEntry.builder().outcome("HTTP_ERROR").requestType("TOURNAMENT").build());
+        String summary = "melbetHttpError";
+        when(repository.findFirstByProviderAndCodeAndLayerAndLeagueCodeAndMessage(
+                "melbet",
+                ErrorLogService.CODE_PROVIDER_FETCH_FAILED,
+                "ODDS",
+                "EPL",
+                summary)).thenReturn(Optional.of(ErrorLog.builder().id("existing").build()));
+
+        service.recordHttpRequestFailuresIfNeeded(
+                ExternalDataLayer.ODDS,
+                "melbet",
+                "EPL",
+                "2025",
+                logs,
+                summary
+        );
+
+        verify(repository, never()).save(any());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- When finalizing an external API monitoring run, log `providerFetchFailed` to the error log if any HTTP request failed and an identical entry does not already exist (dedupe by provider, layer, league, message).
- Builds a descriptive message from HTTP logs when `errorSummary` is absent.

## Test plan

- [x] `mvn test -Dtest=ErrorLogServiceHttpFailuresTest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5443dc1f-1c6f-4da7-86e4-3be9ee769f74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5443dc1f-1c6f-4da7-86e4-3be9ee769f74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

