### PR TITLE
feat(match-results): expose FULL_MATCH team stats in ExternalMatchDto

### DIFF
--- a/src/main/java/net/friendly_bets/dto/ExternalMatchDto.java
+++ b/src/main/java/net/friendly_bets/dto/ExternalMatchDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import net.friendly_bets.models.GameScore;
 import net.friendly_bets.models.schedule.MatchGoalEvent;
+import net.friendly_bets.models.schedule.MatchTeamStats;
 
 import java.time.Instant;
 import java.util.List;
@@ -52,4 +53,6 @@ public class ExternalMatchDto {
     private List<MatchGoalEvent> goals;
     private Integer addedTimeFirstHalf;
     private Integer addedTimeSecondHalf;
+    /** FULL_MATCH team stats (possession, shots, xG, …). */
+    private MatchTeamStats stats;
 }

--- a/src/main/java/net/friendly_bets/services/MatchScheduleDisplayService.java
+++ b/src/main/java/net/friendly_bets/services/MatchScheduleDisplayService.java
@@ -52,6 +52,7 @@ public class MatchScheduleDisplayService {
                 .goals(schedule.getGoals())
                 .addedTimeFirstHalf(schedule.getAddedTimeFirstHalf())
                 .addedTimeSecondHalf(schedule.getAddedTimeSecondHalf())
+                .stats(schedule.getStats())
                 .build();
 
         applyTeamDisplay(dto, true, findTeam(schedule.getHomeTeamId()), schedule.getLeagueCode());


### PR DESCRIPTION
Include MatchTeamStats in the external match API response so the finished-match dialog can render possession, shots, xG and related metrics.