### PR TITLE
Синхронизация алиасов: mismatch count, force overwrite, общий лог

### DIFF
--- a/src/main/java/net/friendly_bets/controllers/ExternalDataAdminController.java
+++ b/src/main/java/net/friendly_bets/controllers/ExternalDataAdminController.java
@@ -85,9 +85,11 @@ public class ExternalDataAdminController {
     @PreAuthorize("hasAuthority('ADMIN')")
     public ResponseEntity<ExternalTeamNamesLoadResultDto> fetchTeamNames(
             @RequestParam String provider,
-            @RequestParam String leagueCode
+            @RequestParam String leagueCode,
+            @RequestParam(defaultValue = "false") boolean forceOverwrite
     ) {
-        return ResponseEntity.ok(externalTeamNamesService.fetchAndAutoBindTeamNames(provider, leagueCode));
+        return ResponseEntity.ok(
+                externalTeamNamesService.fetchAndAutoBindTeamNames(provider, leagueCode, forceOverwrite));
     }
 
     @PostMapping("/schedule/sync")

--- a/src/main/java/net/friendly_bets/dto/ExternalTeamNamesLoadResultDto.java
+++ b/src/main/java/net/friendly_bets/dto/ExternalTeamNamesLoadResultDto.java
@@ -19,6 +19,8 @@ public class ExternalTeamNamesLoadResultDto {
 
     private int autoBoundCount;
     private int mismatchCount;
+    /** Existing provider aliases replaced during force sync. */
+    private int overwrittenCount;
     private int alreadyMappedCount;
     private int totalNames;
 }

--- a/src/main/java/net/friendly_bets/services/ErrorLogService.java
+++ b/src/main/java/net/friendly_bets/services/ErrorLogService.java
@@ -204,6 +204,57 @@ public class ErrorLogService {
                 .build());
     }
 
+    /**
+     * One summary row when team-alias sync detected stored aliases that differ from the API names.
+     */
+    public void recordTeamAliasMismatchSummary(
+            String provider,
+            String leagueCode,
+            List<TeamAliasMismatchDetail> mismatches,
+            boolean overwritten
+    ) {
+        if (mismatches == null || mismatches.isEmpty()) {
+            return;
+        }
+        Map<String, String> context = new LinkedHashMap<>();
+        context.put("count", String.valueOf(mismatches.size()));
+        context.put("overwritten", String.valueOf(overwritten));
+        StringBuilder details = new StringBuilder();
+        for (TeamAliasMismatchDetail mismatch : mismatches) {
+            if (!details.isEmpty()) {
+                details.append("; ");
+            }
+            details.append(mismatch.getTeamTitle())
+                    .append(": \"")
+                    .append(mismatch.getCurrentAlias())
+                    .append("\" -> \"")
+                    .append(mismatch.getIncomingAlias())
+                    .append('"');
+        }
+        context.put("details", details.toString());
+
+        String action = overwritten ? "overwritten during force sync" : "kept unchanged";
+        String message = "Team alias mismatch for " + mismatches.size() + " team(s), " + action;
+
+        record(Entry.builder()
+                .severity(SEVERITY_WARN)
+                .provider(provider)
+                .code(CODE_TEAM_ALIAS_MISMATCH)
+                .message(message)
+                .leagueCode(leagueCode)
+                .context(context)
+                .build());
+    }
+
+    @Value
+    @Builder
+    public static class TeamAliasMismatchDetail {
+        String teamId;
+        String teamTitle;
+        String currentAlias;
+        String incomingAlias;
+    }
+
     public void recordTeamMappingMissing(
             String provider,
             String leagueCode,

--- a/src/main/java/net/friendly_bets/services/ExternalTeamAliasAutoBindService.java
+++ b/src/main/java/net/friendly_bets/services/ExternalTeamAliasAutoBindService.java
@@ -42,6 +42,16 @@ public class ExternalTeamAliasAutoBindService {
             String leagueCodeRaw,
             List<String> externalNames
     ) {
+        return bindAndCollectUnmapped(provider, leagueCodeRaw, externalNames, false);
+    }
+
+    @Transactional
+    public ExternalTeamNamesLoadResultDto bindAndCollectUnmapped(
+            String provider,
+            String leagueCodeRaw,
+            List<String> externalNames,
+            boolean forceOverwrite
+    ) {
         if (provider == null || provider.isBlank()) {
             throw new BadRequestException("externalTeamNamesProviderRequired");
         }
@@ -61,8 +71,10 @@ public class ExternalTeamAliasAutoBindService {
 
         int autoBound = 0;
         int mismatch = 0;
+        int overwritten = 0;
         int alreadyMapped = 0;
         List<ExternalTeamNameChipDto> unmapped = new ArrayList<>();
+        List<ErrorLogService.TeamAliasMismatchDetail> mismatches = new ArrayList<>();
 
         Map<String, Team> teamsById = new LinkedHashMap<>();
         for (Team team : leagueTeams) {
@@ -91,10 +103,22 @@ public class ExternalTeamAliasAutoBindService {
                     alreadyMapped++;
                     continue;
                 }
-                // Team already mapped for this provider (e.g. RU alias vs EN label from the same API).
-                // Keep existing alias; log drift for ops; do not show a chip or toast "mismatch".
-                recordMismatch(provider, leagueCode.name(), candidate, existing.getExternalName(), externalName);
-                alreadyMapped++;
+                mismatches.add(ErrorLogService.TeamAliasMismatchDetail.builder()
+                        .teamId(candidate.getId())
+                        .teamTitle(candidate.getTitle())
+                        .currentAlias(existing.getExternalName())
+                        .incomingAlias(externalName)
+                        .build());
+                mismatch++;
+                if (forceOverwrite) {
+                    bindAlias(candidate, provider, externalName);
+                    teamsRepository.save(candidate);
+                    teamsById.put(candidate.getId(), candidate);
+                    errorLogService.purgeTeamMappingIssuesForExternalTeam(provider, externalName);
+                    overwritten++;
+                } else {
+                    alreadyMapped++;
+                }
                 continue;
             }
 
@@ -110,10 +134,20 @@ public class ExternalTeamAliasAutoBindService {
             autoBound++;
         }
 
+        if (!mismatches.isEmpty()) {
+            errorLogService.recordTeamAliasMismatchSummary(
+                    provider,
+                    leagueCode.name(),
+                    mismatches,
+                    forceOverwrite
+            );
+        }
+
         return ExternalTeamNamesLoadResultDto.builder()
                 .unmapped(unmapped)
                 .autoBoundCount(autoBound)
                 .mismatchCount(mismatch)
+                .overwrittenCount(overwritten)
                 .alreadyMappedCount(alreadyMapped)
                 .totalNames(uniqueNames.size())
                 .build();
@@ -129,35 +163,6 @@ public class ExternalTeamAliasAutoBindService {
         aliases.add(TeamExternalAlias.builder()
                 .provider(provider)
                 .externalName(externalName)
-                .build());
-    }
-
-    private void recordMismatch(
-            String provider,
-            String leagueCode,
-            Team team,
-            String currentAlias,
-            String incomingAlias
-    ) {
-        Map<String, String> context = new LinkedHashMap<>();
-        context.put("teamTitle", team.getTitle() != null ? team.getTitle() : "");
-        context.put("teamId", team.getId() != null ? team.getId() : "");
-        context.put("provider", provider);
-        context.put("currentAlias", currentAlias);
-        context.put("incomingAlias", incomingAlias);
-
-        String message = "Alias mismatch for provider " + provider
-                + ", team " + team.getTitle()
-                + ": current=\"" + currentAlias + "\", incoming=\"" + incomingAlias + "\"";
-
-        errorLogService.record(ErrorLogService.Entry.builder()
-                .severity(ErrorLogService.SEVERITY_WARN)
-                .provider(provider)
-                .code(ErrorLogService.CODE_TEAM_ALIAS_MISMATCH)
-                .message(message)
-                .leagueCode(leagueCode)
-                .homeTeam(team.getTitle())
-                .context(context)
                 .build());
     }
 

--- a/src/main/java/net/friendly_bets/services/ExternalTeamNamesService.java
+++ b/src/main/java/net/friendly_bets/services/ExternalTeamNamesService.java
@@ -34,6 +34,14 @@ public class ExternalTeamNamesService {
     private final ExternalTeamAliasAutoBindService autoBindService;
 
     public ExternalTeamNamesLoadResultDto fetchAndAutoBindTeamNames(String providerRaw, String leagueCode) {
+        return fetchAndAutoBindTeamNames(providerRaw, leagueCode, false);
+    }
+
+    public ExternalTeamNamesLoadResultDto fetchAndAutoBindTeamNames(
+            String providerRaw,
+            String leagueCode,
+            boolean forceOverwrite
+    ) {
         String provider = normalizeProvider(providerRaw);
         List<String> names = switch (provider) {
             case ExternalProviderIds.SOCCER365 -> soccer365TeamNamesService.fetchTeamNames(leagueCode);
@@ -48,7 +56,7 @@ public class ExternalTeamNamesService {
             case ExternalProviderIds.FLASHSCORE -> flashscoreTeamNamesService.fetchTeamNames(leagueCode);
             default -> throw new BadRequestException("externalTeamNamesProviderUnsupported");
         };
-        return autoBindService.bindAndCollectUnmapped(provider, leagueCode, names);
+        return autoBindService.bindAndCollectUnmapped(provider, leagueCode, names, forceOverwrite);
     }
 
     /** @deprecated use {@link #fetchAndAutoBindTeamNames}; kept for legacy soccer365 admin route. */

--- a/src/test/java/net/friendly_bets/services/ExternalTeamAliasAutoBindServiceTest.java
+++ b/src/test/java/net/friendly_bets/services/ExternalTeamAliasAutoBindServiceTest.java
@@ -1,0 +1,147 @@
+package net.friendly_bets.services;
+
+import net.friendly_bets.models.League;
+import net.friendly_bets.models.Season;
+import net.friendly_bets.models.Team;
+import net.friendly_bets.models.TeamDisplayNames;
+import net.friendly_bets.models.TeamExternalAlias;
+import net.friendly_bets.providers.ExternalProviderIds;
+import net.friendly_bets.repositories.TeamsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalTeamAliasAutoBindServiceTest {
+
+    @Mock
+    RunningSeasonLookup runningSeasonLookup;
+    @Mock
+    TeamsRepository teamsRepository;
+    @Mock
+    ErrorLogService errorLogService;
+
+    @InjectMocks
+    ExternalTeamAliasAutoBindService service;
+
+    private Team arsenal;
+
+    @BeforeEach
+    void setUp() {
+        arsenal = Team.builder()
+                .id("ars1")
+                .title("Arsenal")
+                .displayNames(TeamDisplayNames.builder().en("Arsenal").ru("Арсенал").build())
+                .externalAliases(new ArrayList<>(List.of(
+                        TeamExternalAlias.builder()
+                                .provider(ExternalProviderIds.FLASHSCORE)
+                                .externalName("Арсенал")
+                                .build()
+                )))
+                .build();
+
+        League league = League.builder()
+                .leagueCode(League.LeagueCode.EPL)
+                .teams(List.of(arsenal))
+                .build();
+        Season season = Season.builder()
+                .id("s1")
+                .leagues(List.of(league))
+                .build();
+
+        when(runningSeasonLookup.findRunningSeasonOrThrow(any())).thenReturn(season);
+        when(teamsRepository.findById("ars1")).thenReturn(Optional.of(arsenal));
+    }
+
+    @Test
+    void bindAndCollectUnmapped_countsMismatchAndLogsSummaryWithoutOverwrite() {
+        var result = service.bindAndCollectUnmapped(
+                ExternalProviderIds.FLASHSCORE,
+                "EPL",
+                List.of("Arsenal"),
+                false
+        );
+
+        assertEquals(1, result.getMismatchCount());
+        assertEquals(0, result.getOverwrittenCount());
+        assertEquals(1, result.getAlreadyMappedCount());
+        assertEquals("Арсенал", findFlashscoreAlias(arsenal).getExternalName());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ErrorLogService.TeamAliasMismatchDetail>> captor = ArgumentCaptor.forClass(List.class);
+        verify(errorLogService).recordTeamAliasMismatchSummary(
+                eq(ExternalProviderIds.FLASHSCORE),
+                eq("EPL"),
+                captor.capture(),
+                eq(false)
+        );
+        assertEquals(1, captor.getValue().size());
+        assertEquals("Арсенал", captor.getValue().get(0).getCurrentAlias());
+        assertEquals("Arsenal", captor.getValue().get(0).getIncomingAlias());
+        verify(teamsRepository, never()).save(any());
+    }
+
+    @Test
+    void bindAndCollectUnmapped_forceOverwriteReplacesAliasAndCountsOverwritten() {
+        when(teamsRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service.bindAndCollectUnmapped(
+                ExternalProviderIds.FLASHSCORE,
+                "EPL",
+                List.of("Arsenal"),
+                true
+        );
+
+        assertEquals(1, result.getMismatchCount());
+        assertEquals(1, result.getOverwrittenCount());
+        assertEquals(0, result.getAlreadyMappedCount());
+        assertEquals("Arsenal", findFlashscoreAlias(arsenal).getExternalName());
+        verify(teamsRepository).save(arsenal);
+        verify(errorLogService).recordTeamAliasMismatchSummary(
+                eq(ExternalProviderIds.FLASHSCORE),
+                eq("EPL"),
+                any(),
+                eq(true)
+        );
+    }
+
+    @Test
+    void bindAndCollectUnmapped_newAliasAutoBindsWithoutMismatchLog() {
+        arsenal.setExternalAliases(new ArrayList<>());
+        when(teamsRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service.bindAndCollectUnmapped(
+                ExternalProviderIds.FLASHSCORE,
+                "EPL",
+                List.of("Arsenal"),
+                false
+        );
+
+        assertEquals(1, result.getAutoBoundCount());
+        assertEquals(0, result.getMismatchCount());
+        verify(errorLogService, never()).recordTeamAliasMismatchSummary(any(), any(), any(), any(Boolean.class));
+    }
+
+    private static TeamExternalAlias findFlashscoreAlias(Team team) {
+        return team.getExternalAliases().stream()
+                .filter(a -> ExternalProviderIds.FLASHSCORE.equals(a.getProvider()))
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
Исправлен счётчик mismatchCount. Добавлен параметр forceOverwrite: при включении перезаписывает существующие алиасы провайдера и отдаёт overwrittenCount. Рассинхроны пишутся одной записью teamAliasMismatch с деталями в context, а не по команде.