### PR TITLE
Flashscore: имена для синхронизации алиасов из day feed (FH/FK)

### DIFF
--- a/src/main/java/net/friendly_bets/flashscore/FlashscoreTeamNamesService.java
+++ b/src/main/java/net/friendly_bets/flashscore/FlashscoreTeamNamesService.java
@@ -6,57 +6,89 @@ import net.friendly_bets.flashscore.config.FlashscoreProperties;
 import net.friendly_bets.models.League;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+/**
+ * Team names for alias autobind — same canonical FH/FK labels as day feed / FULL_MATCH,
+ * not localized labels from the tournament HTML page.
+ */
 @Service
 @RequiredArgsConstructor
 public class FlashscoreTeamNamesService {
 
-    /** Canonical team labels for alias autobind (FH/FK), not localized CX/AF. */
-    private static final Pattern FEED_NAME_FIELD = Pattern.compile(
-            "(?:FH|FK)÷([^¬~{}]+)"
-    );
+    private static final int DAY_FEED_PAST_DAYS = 7;
+    private static final int DAY_FEED_FUTURE_DAYS = 21;
 
     private final FlashscoreHttpClient httpClient;
+    private final FlashscoreDayFeedParser dayFeedParser;
     private final FlashscoreProperties properties;
 
     public List<String> fetchTeamNames(String leagueCodeRaw) {
         League.LeagueCode leagueCode = FlashscoreFullMatchResolver.parseLeagueCode(leagueCodeRaw);
         FlashscoreProperties.LeagueConfig config = requireLeagueConfig(leagueCode);
-        String html = httpClient.fetchTournamentPageHtml(config.getTournamentPath());
-        List<String> names = parseTeamNamesFromTournamentHtml(html);
-        if (names.isEmpty()) {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        Set<String> unique = new LinkedHashSet<>();
+        for (int offset = -DAY_FEED_PAST_DAYS; offset <= DAY_FEED_FUTURE_DAYS; offset++) {
+            LocalDate day = today.plusDays(offset);
+            String feed = httpClient.fetchDayFootballFeed(day);
+            FlashscoreParsedDayPage page = dayFeedParser.parse(feed, day);
+            unique.addAll(extractTeamNames(page, config));
+        }
+        if (unique.isEmpty()) {
             throw new BadRequestException("flashscoreTeamNamesEmpty");
         }
-        return names;
+        return new ArrayList<>(unique);
     }
 
     FlashscoreProperties.LeagueConfig requireLeagueConfig(League.LeagueCode leagueCode) {
-        Map<String, FlashscoreProperties.LeagueConfig> leagues = properties.getLeagues();
-        FlashscoreProperties.LeagueConfig config = leagues != null ? leagues.get(leagueCode.name()) : null;
+        FlashscoreProperties.LeagueConfig config = properties.getLeagues() != null
+                ? properties.getLeagues().get(leagueCode.name())
+                : null;
         if (config == null || config.getTournamentPath() == null || config.getTournamentPath().isBlank()) {
             throw new BadRequestException("flashscoreTournamentNotConfigured");
         }
         return config;
     }
 
-    static List<String> parseTeamNamesFromTournamentHtml(String html) {
-        if (html == null || html.isBlank()) {
+    static List<String> extractTeamNames(FlashscoreParsedDayPage page, FlashscoreProperties.LeagueConfig config) {
+        if (page == null || page.getCompetitions() == null || config == null) {
             return List.of();
         }
         Set<String> unique = new LinkedHashSet<>();
-        Matcher matcher = FEED_NAME_FIELD.matcher(html);
-        while (matcher.find()) {
-            addName(unique, matcher.group(1));
+        for (FlashscoreParsedDayPage.CompetitionBlock block : page.getCompetitions()) {
+            if (!competitionMatchesLeague(block, config)) {
+                continue;
+            }
+            if (block.getMatches() == null) {
+                continue;
+            }
+            for (FlashscoreParsedDayPage.Match match : block.getMatches()) {
+                addName(unique, match.getHomeName());
+                addName(unique, match.getAwayName());
+            }
         }
         unique.removeIf(FlashscoreTeamNamesService::isCountryLikeName);
         return new ArrayList<>(unique);
+    }
+
+    static boolean competitionMatchesLeague(
+            FlashscoreParsedDayPage.CompetitionBlock block,
+            FlashscoreProperties.LeagueConfig config
+    ) {
+        if (block == null || config == null) {
+            return false;
+        }
+        if (config.getStageId() != null
+                && !config.getStageId().isBlank()
+                && config.getStageId().equalsIgnoreCase(block.getStageId())) {
+            return true;
+        }
+        return FlashscoreDayFeedParser.competitionMatchesFilter(block, config.getTitleContains());
     }
 
     private static boolean isCountryLikeName(String name) {

--- a/src/test/java/net/friendly_bets/flashscore/FlashscoreTeamNamesServiceTest.java
+++ b/src/test/java/net/friendly_bets/flashscore/FlashscoreTeamNamesServiceTest.java
@@ -1,6 +1,13 @@
 package net.friendly_bets.flashscore;
 
+import net.friendly_bets.flashscore.config.FlashscoreProperties;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -9,15 +16,37 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FlashscoreTeamNamesServiceTest {
 
     @Test
-    void parseTeamNamesFromEmbeddedFeedFields() {
-        String html = """
-                data: `SA÷1¬~AA÷x¬CX÷Арсенал¬AF÷Челси¬~AA÷y¬AE÷Ливерпуль¬FK÷Everton¬FH÷Arsenal¬FK÷Chelsea¬`
-                """;
-        var names = FlashscoreTeamNamesService.parseTeamNamesFromTournamentHtml(html);
-        assertTrue(names.contains("Arsenal"));
-        assertTrue(names.contains("Chelsea"));
-        assertTrue(names.contains("Everton"));
-        assertFalse(names.contains("Арсенал"));
-        assertEquals(3, names.size());
+    void extractTeamNamesFromDayFeedUsesCanonicalFhFkLabels() throws IOException {
+        String feed = readFixture("flashscore/day-nurnberg-mini.feed");
+        FlashscoreDayFeedParser parser = new FlashscoreDayFeedParser();
+        FlashscoreParsedDayPage page = parser.parse(feed, LocalDate.of(2026, 8, 12));
+
+        FlashscoreProperties.LeagueConfig bl = new FlashscoreProperties.LeagueConfig();
+        bl.setStageId("6khmdCet");
+        bl.setTitleContains("Bundesliga");
+
+        var names = FlashscoreTeamNamesService.extractTeamNames(page, bl);
+
+        assertTrue(names.contains("Nurnberg"));
+        assertTrue(names.contains("SG Dynamo Dresden"));
+        assertFalse(names.stream().anyMatch(name -> name.contains("Nurnberg") && name.contains("CX")));
+    }
+
+    @Test
+    void competitionMatchesLeagueByStageIdOrTitle() {
+        FlashscoreParsedDayPage.CompetitionBlock block = FlashscoreParsedDayPage.CompetitionBlock.builder()
+                .title("GERMANY: 2. Bundesliga")
+                .stageId("6khmdCet")
+                .build();
+        FlashscoreProperties.LeagueConfig bl = new FlashscoreProperties.LeagueConfig();
+        bl.setStageId("6khmdCet");
+        bl.setTitleContains("Bundesliga");
+
+        assertTrue(FlashscoreTeamNamesService.competitionMatchesLeague(block, bl));
+    }
+
+    private static String readFixture(String resourcePath) throws IOException {
+        Path path = Path.of("src/test/resources", resourcePath);
+        return Files.readString(path, StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
Страница турнира отдавала те же русские строки, что уже в БД — sync считал всё alreadyMapped без рассинхрона. Теперь имена берутся из day feed с теми же каноническими FH/FK, что и при матчах.