### PR TITLE
fix(flashscore): алиасы команд только из страницы лиги по stageId

### DIFF
--- a/src/main/java/net/friendly_bets/flashscore/FlashscoreHttpClient.java
+++ b/src/main/java/net/friendly_bets/flashscore/FlashscoreHttpClient.java
@@ -60,10 +60,14 @@ public class FlashscoreHttpClient {
     }
 
     public String fetchTournamentPageHtml(String tournamentPath) {
+        return fetchTournamentPageHtml(tournamentPath, properties.getBaseUrl());
+    }
+
+    public String fetchTournamentPageHtml(String tournamentPath, String baseUrl) {
         if (tournamentPath == null || tournamentPath.isBlank()) {
             throw new BadRequestException("flashscoreTournamentNotConfigured");
         }
-        String base = trimTrailingSlash(properties.getBaseUrl());
+        String base = trimTrailingSlash(baseUrl != null && !baseUrl.isBlank() ? baseUrl : properties.getBaseUrl());
         String path = tournamentPath.startsWith("/") ? tournamentPath : "/" + tournamentPath;
         if (!path.endsWith("/")) {
             path = path + "/";

--- a/src/main/java/net/friendly_bets/flashscore/FlashscoreTeamNamesService.java
+++ b/src/main/java/net/friendly_bets/flashscore/FlashscoreTeamNamesService.java
@@ -6,43 +6,39 @@ import net.friendly_bets.flashscore.config.FlashscoreProperties;
 import net.friendly_bets.models.League;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Team names for alias autobind — same canonical FH/FK labels as day feed / FULL_MATCH,
- * not localized labels from the tournament HTML page.
+ * Team names for alias autobind — canonical English FH/FK labels from the league
+ * tournament page feed (same strings as day feed / FULL_MATCH), scoped by stage id.
  */
 @Service
 @RequiredArgsConstructor
 public class FlashscoreTeamNamesService {
 
-    private static final int DAY_FEED_PAST_DAYS = 7;
-    private static final int DAY_FEED_FUTURE_DAYS = 21;
+    private static final Pattern EMBEDDED_FEED_BLOCK = Pattern.compile("data: `([^`]+)`");
 
     private final FlashscoreHttpClient httpClient;
-    private final FlashscoreDayFeedParser dayFeedParser;
     private final FlashscoreProperties properties;
 
     public List<String> fetchTeamNames(String leagueCodeRaw) {
         League.LeagueCode leagueCode = FlashscoreFullMatchResolver.parseLeagueCode(leagueCodeRaw);
         FlashscoreProperties.LeagueConfig config = requireLeagueConfig(leagueCode);
-        LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        Set<String> unique = new LinkedHashSet<>();
-        for (int offset = -DAY_FEED_PAST_DAYS; offset <= DAY_FEED_FUTURE_DAYS; offset++) {
-            LocalDate day = today.plusDays(offset);
-            String feed = httpClient.fetchDayFootballFeed(day);
-            FlashscoreParsedDayPage page = dayFeedParser.parse(feed, day);
-            unique.addAll(extractTeamNames(page, config));
-        }
-        if (unique.isEmpty()) {
+        String html = httpClient.fetchTournamentPageHtml(
+                config.getTournamentPath(),
+                properties.getTeamNamesBaseUrl()
+        );
+        List<String> names = parseTeamNamesFromTournamentHtml(html, config.getStageId());
+        if (names.isEmpty()) {
             throw new BadRequestException("flashscoreTeamNamesEmpty");
         }
-        return new ArrayList<>(unique);
+        return names;
     }
 
     FlashscoreProperties.LeagueConfig requireLeagueConfig(League.LeagueCode leagueCode) {
@@ -52,43 +48,48 @@ public class FlashscoreTeamNamesService {
         if (config == null || config.getTournamentPath() == null || config.getTournamentPath().isBlank()) {
             throw new BadRequestException("flashscoreTournamentNotConfigured");
         }
+        if (config.getStageId() == null || config.getStageId().isBlank()) {
+            throw new BadRequestException("flashscoreTournamentNotConfigured");
+        }
         return config;
     }
 
-    static List<String> extractTeamNames(FlashscoreParsedDayPage page, FlashscoreProperties.LeagueConfig config) {
-        if (page == null || page.getCompetitions() == null || config == null) {
+    static List<String> parseTeamNamesFromTournamentHtml(String html, String stageId) {
+        if (html == null || html.isBlank() || stageId == null || stageId.isBlank()) {
             return List.of();
         }
         Set<String> unique = new LinkedHashSet<>();
-        for (FlashscoreParsedDayPage.CompetitionBlock block : page.getCompetitions()) {
-            if (!competitionMatchesLeague(block, config)) {
-                continue;
-            }
-            if (block.getMatches() == null) {
-                continue;
-            }
-            for (FlashscoreParsedDayPage.Match match : block.getMatches()) {
-                addName(unique, match.getHomeName());
-                addName(unique, match.getAwayName());
-            }
+        Matcher matcher = EMBEDDED_FEED_BLOCK.matcher(html);
+        while (matcher.find()) {
+            unique.addAll(extractTeamNamesFromFeedBlock(matcher.group(1), stageId));
         }
         unique.removeIf(FlashscoreTeamNamesService::isCountryLikeName);
         return new ArrayList<>(unique);
     }
 
-    static boolean competitionMatchesLeague(
-            FlashscoreParsedDayPage.CompetitionBlock block,
-            FlashscoreProperties.LeagueConfig config
-    ) {
-        if (block == null || config == null) {
-            return false;
+    static Set<String> extractTeamNamesFromFeedBlock(String feedBlock, String stageId) {
+        Set<String> unique = new LinkedHashSet<>();
+        String currentStageId = null;
+        for (String record : FlashscoreFeedSupport.splitRecords(feedBlock)) {
+            Map<String, String> fields = FlashscoreFeedSupport.parseRecord(record);
+            String za = fields.get("ZA");
+            if (za != null) {
+                currentStageId = fields.get("ZC");
+                continue;
+            }
+            if (!stageId.equalsIgnoreCase(currentStageId != null ? currentStageId : "")) {
+                continue;
+            }
+            if (fields.containsKey("AA")) {
+                addName(unique, fields.get("FH"));
+                addName(unique, fields.get("FK"));
+                continue;
+            }
+            if (fields.containsKey("TN")) {
+                addName(unique, fields.get("TN"));
+            }
         }
-        if (config.getStageId() != null
-                && !config.getStageId().isBlank()
-                && config.getStageId().equalsIgnoreCase(block.getStageId())) {
-            return true;
-        }
-        return FlashscoreDayFeedParser.competitionMatchesFilter(block, config.getTitleContains());
+        return unique;
     }
 
     private static boolean isCountryLikeName(String name) {

--- a/src/main/java/net/friendly_bets/flashscore/config/FlashscoreProperties.java
+++ b/src/main/java/net/friendly_bets/flashscore/config/FlashscoreProperties.java
@@ -11,6 +11,8 @@ import java.util.Map;
 public class FlashscoreProperties {
 
     private String baseUrl = "https://www.flashscorekz.com";
+    /** English tournament pages for admin team-alias sync (FH/FK labels). */
+    private String teamNamesBaseUrl = "https://www.flashscore.com";
     private String feedBaseUrl = "https://46.flashscore.ninja";
     private String feedSign = "SW9D1eZo";
     private String feedLocale = "ru-kz";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -113,6 +113,7 @@ ruscore.tournament-slugs.LE=uefa-europa-league
 
 # ----- flashscorekz.com FULL_MATCH (feed API) -----
 flashscore.base-url=https://www.flashscorekz.com
+flashscore.team-names-base-url=https://www.flashscore.com
 flashscore.feed-base-url=https://46.flashscore.ninja
 flashscore.feed-sign=SW9D1eZo
 flashscore.feed-locale=ru-kz

--- a/src/test/java/net/friendly_bets/flashscore/FlashscoreTeamNamesServiceTest.java
+++ b/src/test/java/net/friendly_bets/flashscore/FlashscoreTeamNamesServiceTest.java
@@ -1,13 +1,8 @@
 package net.friendly_bets.flashscore;
 
-import net.friendly_bets.flashscore.config.FlashscoreProperties;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.LocalDate;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,37 +11,40 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FlashscoreTeamNamesServiceTest {
 
     @Test
-    void extractTeamNamesFromDayFeedUsesCanonicalFhFkLabels() throws IOException {
-        String feed = readFixture("flashscore/day-nurnberg-mini.feed");
-        FlashscoreDayFeedParser parser = new FlashscoreDayFeedParser();
-        FlashscoreParsedDayPage page = parser.parse(feed, LocalDate.of(2026, 8, 12));
-
-        FlashscoreProperties.LeagueConfig bl = new FlashscoreProperties.LeagueConfig();
-        bl.setStageId("6khmdCet");
-        bl.setTitleContains("Bundesliga");
-
-        var names = FlashscoreTeamNamesService.extractTeamNames(page, bl);
-
-        assertTrue(names.contains("Nurnberg"));
-        assertTrue(names.contains("SG Dynamo Dresden"));
-        assertFalse(names.stream().anyMatch(name -> name.contains("Nurnberg") && name.contains("CX")));
+    void parseTeamNamesFromTournamentFeedScopedByStageId() {
+        String html = """
+                <script>
+                data: `SA÷1¬~ZA÷ENGLAND: Premier League¬ZC÷CfoA8Dmm¬ZL÷/football/england/premier-league/¬~AA÷x¬FH÷Arsenal¬FK÷Chelsea¬~AA÷y¬FH÷Liverpool¬FK÷Everton¬`
+                data: `SA÷1¬~ZA÷BHUTAN: Premier League¬ZC÷OtherStage¬~AA÷z¬FH÷Ugyen Academy¬FK÷BFF Academy U19¬`
+                </script>
+                """;
+        var names = FlashscoreTeamNamesService.parseTeamNamesFromTournamentHtml(html, "CfoA8Dmm");
+        assertTrue(names.contains("Arsenal"));
+        assertTrue(names.contains("Chelsea"));
+        assertTrue(names.contains("Liverpool"));
+        assertTrue(names.contains("Everton"));
+        assertFalse(names.contains("Ugyen Academy"));
+        assertFalse(names.contains("BFF Academy U19"));
+        assertEquals(4, names.size());
     }
 
     @Test
-    void competitionMatchesLeagueByStageIdOrTitle() {
-        FlashscoreParsedDayPage.CompetitionBlock block = FlashscoreParsedDayPage.CompetitionBlock.builder()
-                .title("GERMANY: 2. Bundesliga")
-                .stageId("6khmdCet")
-                .build();
-        FlashscoreProperties.LeagueConfig bl = new FlashscoreProperties.LeagueConfig();
-        bl.setStageId("6khmdCet");
-        bl.setTitleContains("Bundesliga");
-
-        assertTrue(FlashscoreTeamNamesService.competitionMatchesLeague(block, bl));
+    void parseTeamNamesFromStandingsRowsWhenPresent() {
+        String html = """
+                data: `SA÷1¬~ZA÷GERMANY: Bundesliga¬ZC÷jg0MwVuC¬~TI÷x¬TN÷Bayern Munich¬~TI÷y¬TN÷Dortmund¬`
+                """;
+        var names = FlashscoreTeamNamesService.parseTeamNamesFromTournamentHtml(html, "jg0MwVuC");
+        assertEquals(2, names.size());
+        assertTrue(names.contains("Bayern Munich"));
+        assertTrue(names.contains("Dortmund"));
     }
 
-    private static String readFixture(String resourcePath) throws IOException {
-        Path path = Path.of("src/test/resources", resourcePath);
-        return Files.readString(path, StandardCharsets.UTF_8);
+    @Test
+    void extractTeamNamesFromFeedBlockReturnsOnlyRequestedStage() {
+        String block = """
+                SA÷1¬~ZA÷ENGLAND: Premier League¬ZC÷CfoA8Dmm¬~AA÷x¬FH÷Arsenal¬FK÷Chelsea¬~ZA÷OTHER¬ZC÷OtherStage¬~AA÷y¬FH÷Ugyen Academy¬FK÷Ararat¬
+                """;
+        Set<String> names = FlashscoreTeamNamesService.extractTeamNamesFromFeedBlock(block, "CfoA8Dmm");
+        assertEquals(Set.of("Arsenal", "Chelsea"), names);
     }
 }


### PR DESCRIPTION
Day feed с фильтром titleContains подтягивал все «Premier League» мира. Теперь имена берутся из embedded feed на странице турнира (АПЛ/БЛ), строго по stageId, с английскими FH/FK с flashscore.com.