### PR TITLE
client-version deploy: POST вместо PUT для совместимости с прокси

### DIFF
--- a/src/main/java/net/friendly_bets/controllers/ClientVersionController.java
+++ b/src/main/java/net/friendly_bets/controllers/ClientVersionController.java
@@ -34,8 +34,9 @@ public class ClientVersionController {
 
     /**
      * CI deploy only. Requires {@code X-Deploy-Token} matching {@code app.deploy.token}.
+     * POST (not PUT) — reverse proxies often block PUT.
      */
-    @PutMapping
+    @PostMapping("/deploy")
     @PreAuthorize("permitAll()")
     public ResponseEntity<ClientVersionDto> setFromDeploy(
             @RequestHeader(value = "X-Deploy-Token", required = false) String token,

--- a/src/main/java/net/friendly_bets/security/config/SecurityConfig.java
+++ b/src/main/java/net/friendly_bets/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/api/login").permitAll()
                 .antMatchers("/api/auth/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/client-version").permitAll()
-                .antMatchers(HttpMethod.PUT, "/api/client-version").permitAll()
+                .antMatchers(HttpMethod.POST, "/api/client-version/deploy").permitAll()
                 .and()
                 .formLogin()
                 .loginProcessingUrl("/api/login")


### PR DESCRIPTION
Прокси friendly-bets.net/backend отдаёт 405 на PUT. CI вызывает POST /api/client-version/deploy.