### PR TITLE
Fix STANDINGS build: missing import and router tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,33 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/application*.yml</include>
+                    <include>**/application*.yaml</include>
+                    <include>**/application*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/application*.yml</exclude>
+                    <exclude>**/application*.yaml</exclude>
+                    <exclude>**/application*.properties</exclude>
+                    <exclude>http/**</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/net/friendly_bets/controllers/MatchResultsController.java
+++ b/src/main/java/net/friendly_bets/controllers/MatchResultsController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.friendly_bets.dto.ExternalMatchdayPageDto;
 import net.friendly_bets.dto.LeagueStandingsPageDto;
 import net.friendly_bets.models.schedule.MatchSchedule;
+import net.friendly_bets.services.LeagueStandingsService;
 import net.friendly_bets.services.MatchScheduleDisplayService;
 import net.friendly_bets.services.MatchScheduleQueryService;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/net/friendly_bets/providers/LayerProviderRouterTest.java
+++ b/src/test/java/net/friendly_bets/providers/LayerProviderRouterTest.java
@@ -46,7 +46,6 @@ class LayerProviderRouterTest {
     primary.failWith = new BadRequestException("currentMatchdayUnresolved");
     assign("primary", "secondary");
     when(registry.findAs("primary", ScheduleProvider.class)).thenReturn(java.util.Optional.of(primary));
-    when(registry.findAs("secondary", ScheduleProvider.class)).thenReturn(java.util.Optional.of(secondary));
 
     assertThrows(BadRequestException.class, () ->
         router.execute(ExternalDataLayer.SCHEDULE, ScheduleProvider.class, p -> p.syncByLeagueCode("EPL", null)));
@@ -62,11 +61,11 @@ class LayerProviderRouterTest {
     when(registry.findAs("primary", ScheduleProvider.class)).thenReturn(java.util.Optional.of(primary));
     when(registry.findAs("secondary", ScheduleProvider.class)).thenReturn(java.util.Optional.of(secondary));
 
-    String result = router.execute(
+    net.friendly_bets.dto.ScheduleSyncResultDto result = router.execute(
         ExternalDataLayer.SCHEDULE,
         ScheduleProvider.class,
         p -> p.syncByLeagueCode("EPL", null));
-    assertEquals("secondary", result);
+    assertEquals("secondary", result.getLeagueCode());
   }
 
   @Test
@@ -76,7 +75,6 @@ class LayerProviderRouterTest {
     primary.failWith = new BadRequestException("mappingFailed");
     assignLive("primary", "secondary");
     when(registry.findAs("primary", LiveMatchProvider.class)).thenReturn(java.util.Optional.of(primary));
-    when(registry.findAs("secondary", LiveMatchProvider.class)).thenReturn(java.util.Optional.of(secondary));
 
     assertThrows(BadRequestException.class, () ->
         router.execute(ExternalDataLayer.LIVE, LiveMatchProvider.class, p -> p.syncLive(null)));
@@ -154,7 +152,7 @@ class LayerProviderRouterTest {
   static final class StubLiveProvider implements LiveMatchProvider {
     final String id;
     RuntimeException failWith;
-    final LiveSyncResult result = new LiveSyncResult(0, 0, 0, 0, 0, java.util.List.of());
+    final LiveSyncResult result = new LiveSyncResult(0, 0, 0, 0, null, java.util.List.of(), java.util.List.of());
 
     StubLiveProvider(String id) {
       this.id = id;


### PR DESCRIPTION
Add LeagueStandingsService import in MatchResultsController, align LayerProviderRouterTest with ScheduleSyncResultDto and LiveSyncResult APIs, and stabilize Maven resource copying (plugin 3.3.1, exclude dev http fixtures from the classpath jar).