### PR TITLE
Rename MongoDB collection team_standings to standings.

### DIFF
--- a/src/main/java/net/friendly_bets/models/schedule/TeamStandings.java
+++ b/src/main/java/net/friendly_bets/models/schedule/TeamStandings.java
@@ -17,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Data
-@Document(collection = "team_standings")
+@Document(collection = "standings")
 @CompoundIndex(name = "season_league", def = "{'season_id': 1, 'league_id': 1}", unique = true)
 public class TeamStandings {
 

--- a/src/main/java/net/friendly_bets/providers/StandingsPersistSupport.java
+++ b/src/main/java/net/friendly_bets/providers/StandingsPersistSupport.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Provider-agnostic persist of {@link StandingsTableSnapshot} into {@code team_standings}.
+ * Provider-agnostic persist of {@link StandingsTableSnapshot} into {@code standings}.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/net/friendly_bets/providers/StandingsProvider.java
+++ b/src/main/java/net/friendly_bets/providers/StandingsProvider.java
@@ -6,7 +6,7 @@ import net.friendly_bets.models.Season;
 import net.friendly_bets.providers.standings.StandingsTableSnapshot;
 
 /**
- * Layer STANDINGS: fetch league table from external source and persist snapshot in {@code team_standings}.
+ * Layer STANDINGS: fetch league table from external source and persist snapshot in {@code standings}.
  */
 public interface StandingsProvider extends ExternalDataProvider {
 

--- a/src/main/java/net/friendly_bets/services/UtcTimestampsMigrationService.java
+++ b/src/main/java/net/friendly_bets/services/UtcTimestampsMigrationService.java
@@ -50,7 +50,7 @@ public class UtcTimestampsMigrationService {
             Map.entry("tournament_archives", List.of("exported_at", "imported_at")),
             Map.entry("app_settings", List.of("client_version.updated_at")),
             Map.entry("playoff_brackets", List.of("updated_at")),
-            Map.entry("team_standings", List.of("updated_at"))
+            Map.entry("standings", List.of("updated_at"))
     );
 
     private final MongoTemplate mongoTemplate;


### PR DESCRIPTION
No data migration needed — collection was not yet used in production.